### PR TITLE
feat(plugin-electron): patch packaged executable with gpupatch

### DIFF
--- a/.changeset/gpupatch-integration.md
+++ b/.changeset/gpupatch-integration.md
@@ -1,0 +1,11 @@
+---
+"@pipelab/app": minor
+---
+
+feat(plugin-electron): add "Patch executable" option to force high-performance GPU on Windows
+
+Adds a "Patch executable" checkbox to the Electron plugin. When enabled, the packaged
+Windows executable is patched with [gpupatch](https://github.com/CynToolkit/gpupatch)
+to inject `NvOptimusEnablement` and `AmdPowerXpressRequestHighPerformance`, forcing the
+app to use the discrete GPU on laptops. The gpupatch CLI is downloaded on first use and
+the option is surfaced as Windows-only in the UI.

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -43,6 +43,7 @@ declare namespace DesktopApp {
     electronVersion: string
     disableAsarPackaging: boolean
     forceHighPerformanceGpu: boolean
+    patchExecutable: boolean
     clearServiceWorkerOnBoot: boolean
   }
 

--- a/src/main/presets/c3toSteam.ts
+++ b/src/main/presets/c3toSteam.ts
@@ -185,6 +185,10 @@ export const c3toSteamPreset: PresetFn = async () => {
               editor: 'simple',
               value: 'false'
             },
+            patchExecutable: {
+              editor: 'simple',
+              value: 'false'
+            },
             websocketApi: {
               editor: 'simple',
               value: '[]'

--- a/src/shared/libs/plugin-electron/forge.ts
+++ b/src/shared/libs/plugin-electron/forge.ts
@@ -17,6 +17,7 @@ import { app } from 'electron'
 import { detectRuntime } from '@@/plugins'
 import { dirname } from 'node:path'
 import * as esbuild from 'esbuild'
+import { patchExecutableWithGpupatch } from './gpupatch'
 
 // TODO: https://js.electronforge.io/modules/_electron_forge_core.html
 
@@ -329,6 +330,17 @@ export const configureParams = {
     description:
       'Enabling this forces the app to always use the high-performance GPU, which can improve rendering but may increase power consumption.',
     label: 'Force high performance GPU',
+    value: false,
+    control: {
+      type: 'boolean'
+    }
+  },
+  patchExecutable: {
+    required: false,
+    description:
+      'Whether to patch the packaged executable with gpupatch to force high-performance discrete GPU utilization on Windows laptops.',
+    label: 'Patch executable',
+    platforms: ['win32'],
     value: false,
     control: {
       type: 'boolean'
@@ -890,10 +902,19 @@ export const forge = async (
       const binName = getBinName(completeConfiguration.name)
 
       const output = join(destinationFolder, 'out', outName)
+      const binary = join(output, binName)
+
+      if (completeConfiguration.patchExecutable) {
+        await patchExecutableWithGpupatch(binary, finalPlatform as NodeJS.Platform, {
+          log,
+          abortSignal
+        })
+      }
+
       setOutput('output', output)
       return {
         folder: output,
-        binary: join(output, binName)
+        binary
       }
     } else {
       const output = join(destinationFolder, 'out', 'make')

--- a/src/shared/libs/plugin-electron/gpupatch.spec.ts
+++ b/src/shared/libs/plugin-electron/gpupatch.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { gpupatchAssetName } from './gpupatch.js'
+
+test('maps supported host platforms and architectures to gpupatch assets', () => {
+  expect(gpupatchAssetName('win32', 'x64')).toBe('gpupatch-cli-x86_64-pc-windows-msvc.exe')
+  expect(gpupatchAssetName('linux', 'x64')).toBe('gpupatch-cli-x86_64-unknown-linux-gnu')
+  expect(gpupatchAssetName('darwin', 'x64')).toBe('gpupatch-cli-x86_64-apple-darwin')
+  expect(gpupatchAssetName('darwin', 'arm64')).toBe('gpupatch-cli-aarch64-apple-darwin')
+})
+
+test('throws for unsupported platforms and architectures', () => {
+  expect(() => gpupatchAssetName('linux', 'arm64')).toThrow()
+  expect(() => gpupatchAssetName('win32', 'ia32')).toThrow()
+  expect(() => gpupatchAssetName('win32', 'arm64')).toThrow()
+  expect(() => gpupatchAssetName('freebsd', 'x64')).toThrow()
+})

--- a/src/shared/libs/plugin-electron/gpupatch.ts
+++ b/src/shared/libs/plugin-electron/gpupatch.ts
@@ -1,0 +1,104 @@
+import { downloadFile, fileExists, runWithLiveLogs } from '../plugin-core'
+import { chmod, mkdir, rename } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const GPUPATCH_RELEASE = 'latest'
+
+export const gpupatchAssetName = (platform: NodeJS.Platform, arch: NodeJS.Architecture): string => {
+  if (platform === 'darwin') {
+    if (arch === 'arm64') {
+      return 'gpupatch-cli-aarch64-apple-darwin'
+    }
+    if (arch === 'x64') {
+      return 'gpupatch-cli-x86_64-apple-darwin'
+    }
+  } else if (platform === 'linux') {
+    if (arch === 'x64') {
+      return 'gpupatch-cli-x86_64-unknown-linux-gnu'
+    }
+  } else if (platform === 'win32') {
+    if (arch === 'x64') {
+      return 'gpupatch-cli-x86_64-pc-windows-msvc.exe'
+    }
+  }
+  throw new Error(`gpupatch is not available for ${platform}-${arch}`)
+}
+
+export const ensureGpupatch = async (
+  log: typeof console.log,
+  abortSignal?: AbortSignal
+): Promise<string> => {
+  const { app } = await import('electron')
+  const userData = app.getPath('userData')
+  const gpupatchFolder = join(userData, 'thirdparty', 'gpupatch')
+  const extension = process.platform === 'win32' ? '.exe' : ''
+  const gpupatchPath = join(gpupatchFolder, `gpupatch-cli${extension}`)
+
+  if (await fileExists(gpupatchPath)) {
+    return gpupatchPath
+  }
+
+  const assetName = gpupatchAssetName(process.platform, process.arch)
+  const url = `https://github.com/CynToolkit/gpupatch/releases/${GPUPATCH_RELEASE}/download/${assetName}`
+
+  log('Downloading gpupatch from', url)
+
+  await mkdir(gpupatchFolder, { recursive: true })
+
+  await downloadFile(
+    url,
+    gpupatchPath,
+    {
+      onProgress: ({ progress }) => {
+        log(`Downloading gpupatch: ${progress.toFixed(2)}%`)
+      }
+    },
+    abortSignal
+  )
+
+  if (process.platform !== 'win32') {
+    await chmod(gpupatchPath, 0o755)
+  }
+
+  return gpupatchPath
+}
+
+export const patchExecutableWithGpupatch = async (
+  binaryPath: string,
+  targetPlatform: NodeJS.Platform,
+  { log, abortSignal }: { log: typeof console.log; abortSignal?: AbortSignal }
+): Promise<void> => {
+  if (targetPlatform !== 'win32') {
+    log('gpupatch only supports Windows executables, skipping patch')
+    return
+  }
+
+  const exePath = binaryPath.endsWith('.exe') ? binaryPath : `${binaryPath}.exe`
+
+  log('Patching executable with gpupatch:', exePath)
+
+  const gpupatchPath = await ensureGpupatch(log, abortSignal)
+
+  const patchedPath = `${exePath}.gpupatch`
+
+  await runWithLiveLogs(
+    gpupatchPath,
+    [exePath, patchedPath],
+    {
+      cancelSignal: abortSignal
+    },
+    log,
+    {
+      onStderr(data) {
+        log(data)
+      },
+      onStdout(data) {
+        log(data)
+      }
+    }
+  )
+
+  await rename(patchedPath, exePath)
+
+  log('Patched executable with gpupatch')
+}

--- a/src/shared/libs/plugin-electron/package-v2.ts
+++ b/src/shared/libs/plugin-electron/package-v2.ts
@@ -20,6 +20,7 @@ export const packageV2Runner = createActionRunner<ReturnType<typeof createPackag
       electronVersion: options.inputs['electronVersion'],
       disableAsarPackaging: options.inputs['disableAsarPackaging'],
       forceHighPerformanceGpu: options.inputs['forceHighPerformanceGpu'],
+      patchExecutable: options.inputs['patchExecutable'],
       enableExtraLogging: options.inputs['enableExtraLogging'],
       clearServiceWorkerOnBoot: options.inputs['clearServiceWorkerOnBoot'],
       enableDisableRendererBackgrounding: options.inputs['enableDisableRendererBackgrounding'],

--- a/src/shared/libs/plugin-electron/utils.ts
+++ b/src/shared/libs/plugin-electron/utils.ts
@@ -10,6 +10,7 @@ export const defaultElectronConfig = {
   electronVersion: '',
   disableAsarPackaging: true,
   forceHighPerformanceGpu: false,
+  patchExecutable: false,
   enableExtraLogging: false,
   clearServiceWorkerOnBoot: false,
   enableDisableRendererBackgrounding: false,


### PR DESCRIPTION
## What
Adds a **"Patch executable"** checkbox to the Electron plugin. When enabled, the packaged Windows executable is patched with [gpupatch](https://github.com/CynToolkit/gpupatch), which injects `NvOptimusEnablement` and `AmdPowerXpressRequestHighPerformance` so the app always uses the discrete GPU on laptops.

## How
- New `patchExecutable` boolean input surfaced as **Windows-only** via the `platforms: ['win32']` chip (see `ParamEditor.vue`).
- `src/shared/libs/plugin-electron/gpupatch.ts` maps the host platform/arch to a gpupatch release asset, downloads the CLI once to `<userData>/thirdparty/gpupatch`, and patches the packaged exe in place (temp file + rename to avoid the CLI's interactive stdin wait).
- `forge()` runs the patch after a `package` build when enabled; non-win32 targets are skipped with a log message.
- Wired through `package-v2.ts`, defaults in `utils.ts`, `DesktopApp.Electron` type, and the `c3toSteam` preset.

## Testing
- Unit tests for the asset-name mapping (`gpupatch.spec.ts`) — 24/24 tests pass.
- `typecheck:node`: no new errors (59 pre-existing, unrelated).
- ESLint clean on new files.

## Notes
- Includes a changeset (`minor`) per repo convention.
- Runs on the host OS and patches the win32 target binary, so Windows builds can be patched from any supported host.
